### PR TITLE
WI-513: Add child objectives to OKR DTOs and display in project objectives table

### DIFF
--- a/api/src/okrs/dtos.ts
+++ b/api/src/okrs/dtos.ts
@@ -110,6 +110,25 @@ export interface OKRDto {
       reference: string;
       title: string;
     };
+    childObjectives: {
+      id: string;
+      reference: string;
+      title: string;
+      status: string;
+      level: string;
+      timeline: string;
+      progress: number;
+      project: {
+        id: string;
+        name: string;
+      },
+      assignedTo: {
+        id: string;
+        name: string;
+      };
+      createdAt: Date;
+      updatedAt: Date;
+    }[];
     reference: string;
     title: string;
     progress: number;

--- a/api/src/okrs/mappers.ts
+++ b/api/src/okrs/mappers.ts
@@ -14,6 +14,7 @@ export class OKRMapper {
     const org = await objective.org;
     const project = await objective.project;
     const parentObjective = await objective.parentObjective;
+    const childObjectives = await objective.childObjectives;
     return {
       objective: {
         id: objective.id,
@@ -40,6 +41,9 @@ export class OKRMapper {
               title: parentObjective.title,
             }
           : undefined,
+        childObjectives: childObjectives
+          ? await OKRMapper.toChildObjectivesDTO(childObjectives)
+          : [],
         startDate: objective.startDate,
         endDate: objective.endDate,
         assignedTo: assignedTo
@@ -70,6 +74,10 @@ export class OKRMapper {
     return await Promise.all(objectives.map(OKRMapper.toListItemDto));
   }
 
+  static async toChildObjectivesDTO(objectives: Objective[]) {
+    return await Promise.all(objectives.map(OKRMapper.toChildObjectiveItemDto));
+  }
+
   static async toListItemDto(objective: Objective) {
     const assignedTo = await objective.assignedTo;
     return {
@@ -89,6 +97,32 @@ export class OKRMapper {
             name: assignedTo.name,
           }
         : null,
+      createdAt: objective.createdAt,
+      updatedAt: objective.updatedAt,
+    };
+  }
+
+  static async toChildObjectiveItemDto(objective: Objective) {
+    const assignedTo = await objective.assignedTo;
+    const project = await objective.project;
+    return {
+      id: objective.id,
+      reference: objective.reference,
+      title: objective.title,
+      status: objective.status,
+      level: objective.level,
+      timeline: TimelineService.startAndEndDatesToTimeline(
+        objective.startDate,
+        objective.endDate,
+      ),
+      progress: parseFloat(objective.progress?.toFixed(2)),
+      assignedTo: assignedTo
+        ? {
+            id: assignedTo.id,
+            name: assignedTo.name,
+          }
+        : null,
+      project: project ? { id: project.id, name: project.name } : undefined,
       createdAt: objective.createdAt,
       updatedAt: objective.updatedAt,
     };

--- a/web/src/views/pages/okrs/DetailOrgOKR.js
+++ b/web/src/views/pages/okrs/DetailOrgOKR.js
@@ -394,7 +394,7 @@ function DetailOrgOKR() {
                   </>}
               </CardBody>
             </Card>
-            {!isLoading &&
+            {!isLoading && <>
               <Card>
                 <CardHeader>
                   <h3 className="mb-0">
@@ -518,7 +518,83 @@ function DetailOrgOKR() {
                     </div>
                   </Col>
                 </Row>
-              </Card>}
+              </Card>
+              <Card>
+                <CardHeader>
+                  <h3 className="mb-0">
+                    Related Project Objectives
+                  </h3>
+                </CardHeader>
+                <Row>
+                  <Col>
+                    <div className="table-responsive">
+                      <Table className="table align-items-center no-select" style={{ minWidth: '700px' }}
+                             onContextMenu={(e) => e.preventDefault()}>
+                        <thead className="thead-light">
+                        <tr>
+                          <th className="sort" scope="col" width="5%">
+                            Reference
+                          </th>
+                          <th className="sort" scope="col" width="30%">
+                            Objective
+                          </th>
+                          <th className="sort" scope="col" width="30%">
+                            Project
+                          </th>
+                          <th className="sort" scope="col" width="30%">
+                            Progress
+                          </th>
+                        </tr>
+                        </thead>
+                        <tbody className="list">
+                        {okr && okr.objective.childObjectives && okr.objective.childObjectives.length === 0 &&
+                          <tr>
+                            <td colSpan={4}>
+                              <div className="text-center text-muted">
+                                No project objectives have been added yet
+                              </div>
+                            </td>
+                          </tr>}
+                        {okr && okr.objective.childObjectives && okr.objective.childObjectives.map((projectObjective) => (
+                          <tr key={projectObjective.id}>
+                            <td>
+                              <Link
+                                to={`/admin/orgs/${orgId}/projects/${projectObjective.project.id}/okrs/detail/${projectObjective.id}`}
+                                className={'okr-detail'}>
+                                {projectObjective.reference}
+                              </Link>
+                            </td>
+                            <td className="title-cell">
+                              <Link
+                                to={`/admin/orgs/${orgId}/projects/${projectObjective.project.id}/okrs/detail/${projectObjective.id}`}
+                                className={'okr-detail'}>
+                                {projectObjective.title}
+                              </Link>
+                            </td>
+                            <td className="title-cell">
+                              <Link
+                                to={`/admin/orgs/${orgId}/projects/${projectObjective.project.id}/okrs`}
+                                className={'okr-detail'}>
+                                {projectObjective.project.name}
+                              </Link>
+                            </td>
+                            <td>
+                              <div className="d-flex align-items-center">
+                                <span className="mr-2">{formatOKRsProgress(projectObjective.progress)}%</span>
+                                <div>
+                                  <Progress max="100" value={formatOKRsProgress(projectObjective.progress)}
+                                            color="primary" />
+                                </div>
+                              </div>
+                            </td>
+                          </tr>))}
+                        </tbody>
+                      </Table>
+                    </div>
+                  </Col>
+                </Row>
+              </Card>
+            </>}
           </Col>
           {!isLoading &&
             <Col lg={4} md={12}>


### PR DESCRIPTION
- Extended backend to include child objectives in OKR DTOs using `toChildObjectivesDTO`.
- Added frontend support to display related project objectives in a new table within the OKR detail page.