### PR TITLE
Add GitLab repository cleanup when unlinking projects

### DIFF
--- a/api/src/gitlab/gitlab.service.ts
+++ b/api/src/gitlab/gitlab.service.ts
@@ -598,7 +598,6 @@ export class GitlabService {
       project: { id: projectId },
     });
 
-    // Delete project branches
     await this.gitlabBranchRepository.delete({
       project: { id: projectId },
     });


### PR DESCRIPTION
- Introduced `cleanupGitlabRepoAssociations` method to delete associated merge requests and branches.
- Updated `gitlab.service.ts` to invoke cleanup on project unlinking for better data consistency.