### PR TITLE
WI-533: Refactor initiative assignment logic for reusability

### DIFF
--- a/web/src/views/pages/roadmap/InitiativesRoadmap.js
+++ b/web/src/views/pages/roadmap/InitiativesRoadmap.js
@@ -122,16 +122,24 @@ function InitiativesRoadmap() {
     setInitiatives([...sortByPriority(updatedInitiativesList)]);
   }
 
-  async function updateBacklogInitiativesAssignedTo(updatedInitiatives, newAssignedTo) {
-    const user = await getUser(orgId, newAssignedTo);
+  function updateInitiativesUser(updatedInitiatives, newAssignedTo) {
     const updatedInitiativesIds = updatedInitiatives.map(f => f.id);
     const updatedInitiativesList = initiatives.map(initiative => {
       if (updatedInitiativesIds.includes(initiative.id)) {
-        initiative.assignedTo = user;
+        initiative.assignedTo = newAssignedTo;
       }
       return initiative;
     });
     setInitiatives([...sortByPriority(updatedInitiativesList)]);
+  }
+
+  async function updateBacklogInitiativesAssignedTo(updatedInitiatives, newAssignedTo) {
+    if (!newAssignedTo) {
+      updateInitiativesUser(updatedInitiatives, newAssignedTo);
+      return;
+    }
+    const user = await getUser(orgId, newAssignedTo);
+    updateInitiativesUser(updatedInitiatives, user);
   }
 
   async function onAddInitiative(initiative) {

--- a/web/src/views/pages/roadmap/Milestone.js
+++ b/web/src/views/pages/roadmap/Milestone.js
@@ -4,6 +4,7 @@ import { Col, Row } from 'reactstrap';
 import { Link, useParams } from 'react-router-dom';
 import { addInitiative } from '../../../services/roadmap/roadmap.service';
 import { getUser } from '../../../services/okrs/okrs.service';
+import { sortByPriority } from '../../../services/utils/utils';
 
 function Milestone({ milestone, onInitiativeChangeMilestone }) {
   const { orgId, projectId } = useParams();
@@ -70,16 +71,24 @@ function Milestone({ milestone, onInitiativeChangeMilestone }) {
     setInitiatives(updatedInitiativesPriority);
   }
 
-  async function updateInitiativesAssignedTo(updatedInitiatives, assignedTo) {
-    const user = await getUser(orgId, assignedTo);
-    const updatedInitiativesIds = updatedInitiatives.map(initiative => initiative.id);
-    const updatedInitiativesAssignedTo = initiatives.map(initiative => {
+  function updateInitiativesUser(updatedInitiatives, newAssignedTo) {
+    const updatedInitiativesIds = updatedInitiatives.map(f => f.id);
+    const updatedInitiativesList = initiatives.map(initiative => {
       if (updatedInitiativesIds.includes(initiative.id)) {
-        initiative.assignedTo = user;
+        initiative.assignedTo = newAssignedTo;
       }
       return initiative;
     });
-    setInitiatives(updatedInitiativesAssignedTo);
+    setInitiatives([...sortByPriority(updatedInitiativesList)]);
+  }
+
+  async function updateInitiativesAssignedTo(updatedInitiatives, newAssignedTo) {
+    if (!newAssignedTo) {
+      updateInitiativesUser(updatedInitiatives, newAssignedTo);
+      return;
+    }
+    const user = await getUser(orgId, newAssignedTo);
+    updateInitiativesUser(updatedInitiatives, user);
   }
 
   return (


### PR DESCRIPTION
Refactored initiative assignment by splitting user update functionality into a reusable function. This improves code clarity, reduces duplication, and ensures consistent handling of initiative updates across components.