### PR TITLE
WI-535: Remove UserHelp and Termly integration from the admin application

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -44,14 +44,6 @@
     rel="stylesheet"
   />
   <title>Floumy</title>
-  <script
-    src="https://app.termly.io/resource-blocker/1da3cf16-269c-4df6-ae22-fb3909205cf9?autoBlock=on"
-    type="text/javascript"
-  ></script>
-  <script>
-    window.UserHelpPublicProjectID = "w0yp1Eo4X";
-  </script>
-  <script async src="https://run.userhelp.co"></script>
   <!--  Umami Tracking-->
   <script data-website-id="72c0ad3c-b846-4f74-bc96-223c1426763e" defer src="https://cloud.umami.is/script.js"></script>
   <!--  Umami Tracking-->

--- a/web/src/layouts/Admin.js
+++ b/web/src/layouts/Admin.js
@@ -68,15 +68,6 @@ function Admin() {
     localStorage.setItem('lastVisitedProjectId', projectId);
   }, [projectId]);
 
-  const helpButtonStyle = {
-    backgroundColor: 'rgb(0, 0, 0)',
-    color: 'rgb(255, 255, 255)',
-    display: 'flex',
-    alignItems: 'center',
-    transform: 'rotate(-90deg) translateX(calc(124px))',
-    visibility: 'visible',
-  };
-
   return (
     <>
       <BuildInPublicProvider orgId={orgId} projectId={projectId}>
@@ -110,11 +101,6 @@ function Admin() {
             {sidenavOpen ? (
               <div className="backdrop d-xl-none" onClick={toggleSidenav} onKeyDown={toggleSidenav} role="button" />
             ) : null}
-            <button id="userHelpButton" className="userHelpButtonMiddleRight" data-drawer-trigger="true"
-                    aria-controls="drawer-name" aria-expanded="false"
-                    style={helpButtonStyle}>Report
-              a problem
-            </button>
           </ProjectsProvider>
         </OrgProvider>
       </BuildInPublicProvider>

--- a/web/src/layouts/Org.js
+++ b/web/src/layouts/Org.js
@@ -46,15 +46,6 @@ function OrgLayout() {
     }
   }, []);
 
-  const helpButtonStyle = {
-    backgroundColor: 'rgb(0, 0, 0)',
-    color: 'rgb(255, 255, 255)',
-    display: 'flex',
-    alignItems: 'center',
-    transform: 'rotate(-90deg) translateX(calc(124px))',
-    visibility: 'visible',
-  };
-
   return (
     <OrgProvider orgId={orgId}>
       <OrgSidebar
@@ -84,11 +75,6 @@ function OrgLayout() {
       {sidenavOpen ? (
         <div className="backdrop d-xl-none" onClick={toggleSidenav} onKeyDown={toggleSidenav} role="button" />
       ) : null}
-      <button id="userHelpButton" className="userHelpButtonMiddleRight" data-drawer-trigger="true"
-              aria-controls="drawer-name" aria-expanded="false"
-              style={helpButtonStyle}>Report
-        a problem
-      </button>
     </OrgProvider>
   );
 }


### PR DESCRIPTION
This commit removes all references to the UserHelp feature, including its button in the Admin and Org layouts, as well as related scripts in the index.html file. This action streamlines the codebase by eliminating an unused or deprecated feature.