### PR TITLE
WI-537: Refactor OKR stats method and improve imports formatting

### DIFF
--- a/web/src/services/okrs/okrs.service.js
+++ b/web/src/services/okrs/okrs.service.js
@@ -192,6 +192,15 @@ export async function getOkrStats(orgId, projectId, timeline) {
   }
 }
 
+export async function getPublicOkrStats(orgId, projectId, timeline) {
+  try {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/public/orgs/${orgId}/projects/${projectId}/okrs-stats/timeline/${timeline}`);
+    return response.data;
+  } catch (e) {
+    throw new Error(e.message);
+  }
+}
+
 export async function getUser(orgId, userId) {
   try {
     const response = await api.get(`${process.env.REACT_APP_API_URL}/orgs/${orgId}/users/${userId}`);

--- a/web/src/views/pages/okrs/PublicOKRs.js
+++ b/web/src/views/pages/okrs/PublicOKRs.js
@@ -1,16 +1,16 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from 'react';
 // javascript plugin that creates a sortable object from a dom object
 // reactstrap components
-import {Badge, Card, CardBody, CardHeader, Col, Container, Progress, Row, Table} from "reactstrap";
+import { Badge, Card, CardBody, CardHeader, Col, Container, Progress, Row, Table } from 'reactstrap';
 // core components
-import SimpleHeader from "components/Headers/SimpleHeader.js";
-import {Link, useLocation, useNavigate, useParams} from "react-router-dom";
-import {getOkrStats, listPublicObjectives} from "../../../services/okrs/okrs.service";
-import Select2 from "react-select2-wrapper";
-import {formatHyphenatedString, formatOKRsProgress, okrStatusColorClassName} from "../../../services/utils/utils";
-import InfiniteLoadingBar from "../components/InfiniteLoadingBar";
-import LoadingSpinnerBox from "../components/LoadingSpinnerBox";
-import PublicShareButtons from "../../../components/PublicShareButtons/PublicShareButtons";
+import SimpleHeader from 'components/Headers/SimpleHeader.js';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { getPublicOkrStats, listPublicObjectives } from '../../../services/okrs/okrs.service';
+import Select2 from 'react-select2-wrapper';
+import { formatHyphenatedString, formatOKRsProgress, okrStatusColorClassName } from '../../../services/utils/utils';
+import InfiniteLoadingBar from '../components/InfiniteLoadingBar';
+import LoadingSpinnerBox from '../components/LoadingSpinnerBox';
+import PublicShareButtons from '../../../components/PublicShareButtons/PublicShareButtons';
 
 function PublicOKRs() {
     const {orgId, projectId} = useParams();
@@ -52,7 +52,7 @@ function PublicOKRs() {
             setStatsLoading(true);
             setStatsError(null);
             try {
-                const statsData = await getOkrStats(orgId, projectId, timelineQueryFilter);
+                const statsData = await getPublicOkrStats(orgId, projectId, timelineQueryFilter);
                 setStats(statsData);
             } catch (e) {
                 setStatsError('Could not load stats');


### PR DESCRIPTION
Replaced `getOkrStats` with a new `getPublicOkrStats` method to better align with public OKR endpoints. Standardized import formatting for readability and consistency. These changes improve clarity and ensure correct API usage.